### PR TITLE
removed function that prevented RNF from working with React >= 0.47

### DIFF
--- a/android/src/main/java/com/benwixen/rnfilesystem/RNFileSystemPackage.java
+++ b/android/src/main/java/com/benwixen/rnfilesystem/RNFileSystemPackage.java
@@ -16,11 +16,6 @@ public class RNFileSystemPackage implements ReactPackage {
   }
 
   @Override
-  public List<Class<? extends JavaScriptModule>> createJSModules() {
-    return Collections.emptyList();
-  }
-
-  @Override
   public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
     return Collections.emptyList();
   }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-native-filesystem",
   "description": "Simple file system API for iOS & Android.",
   "author": "Ben Wixen <benwixen@gmail.com>",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "main": "modules/FileSystem.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -20,7 +20,7 @@
   ],
   "peerDependencies": {
     "react": ">=15.3.1",
-    "react-native": ">=0.34"
+    "react-native": ">=0.47"
   },
   "license": "Apache-2.0",
   "rnpm": {


### PR DESCRIPTION
React deprecated an (unused) function that this lib was @overriding. I removed it because otherwise cannot use RNF with React Native >= 0.47.